### PR TITLE
No changes to id_protection when unset

### DIFF
--- a/logicboxes.php
+++ b/logicboxes.php
@@ -546,14 +546,15 @@ class Logicboxes extends RegistrarModule
                 $domains = new LogicboxesDomains($api);
             }
 
-            // Handle whois privacy via config option
+            // Handle whois privacy via config option, only when the desired state changes
             $id_protection = $this->featureServiceEnabled('id_protection', $service);
-            if (!$id_protection && isset($vars['configoptions']['id_protection'])) {
-                // Enable whois privacy
+            $wants_id_protection = isset($vars['configoptions']['id_protection']);
+            if (!$id_protection && $wants_id_protection) {
+                // Enable whois privacy (newly purchased)
                 $response = $domains->modifyPrivacyProtection(['order-id' => $order_id, 'protect-privacy' => 'true', 'reason' => 'Module Action']);
                 $this->processResponse($api, $response);
-            } else {
-                // Disable whois privacy
+            } elseif ($id_protection && !$wants_id_protection) {
+                // Disable whois privacy (only when previously purchased)
                 $response = $domains->modifyPrivacyProtection(['order-id' => $order_id, 'protect-privacy' => 'false', 'reason' => 'Module Action']);
                 $this->processResponse($api, $response);
             }


### PR DESCRIPTION
## Summary
Fixes a "privacy protection not purchased" error when managing and saving a domain with **Use Module** selected.

## Root cause
In `editService()`, the whois-privacy block used an `if/else` where the `else` branch unconditionally called `modifyPrivacyProtection(['protect-privacy' => 'false', ...])` on every "Use Module" save. For a domain that never had privacy protection purchased, LogicBoxes rejects that disable call with the *"privacy protection not purchased"* error. It would also wrongly disable privacy that is still selected.

## Fix
Only call the API when the desired state (`$vars['configoptions']['id_protection']`) differs from the current state:
- **enable** — not currently active and now selected (newly purchased)
- **disable** — currently active and no longer selected (only runs when previously purchased)
- **no change** — no API call

This eliminates the spurious error and prevents a still-selected privacy option from being disabled.